### PR TITLE
Add spark-hive to our assembly so we can run hivecontexts

### DIFF
--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -73,6 +73,12 @@
       <artifactId>spark-sql_${scala.binary.version}</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!-- Since we want to use the hive context we (Alpine) have this additional dep -->
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-hive_${scala.binary.version}</artifactId>
+      <version>${project.version}</version>
+    </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-repl_${scala.binary.version}</artifactId>


### PR DESCRIPTION
note there is a weirdness with sbt and deps but we get around this by using the assembly anyways so I'm electing not to fix it for now but as a note for whoever is looking at pom.xml's git log next: sbt v. maven aren't always the same)